### PR TITLE
Replace instances of the word "nudge" with "tip".

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Urlbar Nudges Experiment Extension
+# Urlbar Tips Experiment Extension
 
-This is the extension for the urlbar nudges add-on experiment. When installed,
-Firefox will show a "nudge" or "tip" in the urlbar view in certain situations
-that informs the user they can search directly from the urlbar.
+This is the extension for the urlbar tips add-on experiment. When installed,
+Firefox will show a "tip" in the urlbar view in certain situations that informs
+the user they can search directly from the urlbar.
 
 [Bug 1568594] is the meta bug that tracks this experiment.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "urlbar-nudges-experiment",
+  "name": "urlbar-tips",
   "version": "1.0.0",
-  "description": "Shows nudges or tips in the urlbar view in certain situations.",
+  "description": "Shows tips in the urlbar view in certain situations.",
   "private": true,
   "license": "MPLv2",
   "webExt": {

--- a/src/background.js
+++ b/src/background.js
@@ -140,7 +140,7 @@ async function onTabUpdated(tabId, changeInfo, tabInfo) {
   await isDefaultEngineHomepage(tabInfo.url).then(function(isHomepage) {
     sendTestMessage("Page is engine homepage: " + isHomepage);
     if (isHomepage && new URL(tabInfo.url).hostname != "example.com") {
-      // TODO: Display nudge.
+      // TODO: Display tip.
     }
   });
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,17 +1,17 @@
 {
   "manifest_version": 2,
-  "name": "Urlbar Nudges Experiment",
+  "name": "Urlbar Tips",
   "version": "1.0.0",
-  "description": "Shows nudges or tips in the urlbar view in certain situations.",
+  "description": "Shows tips in the urlbar view in certain situations.",
   "applications": {
     "gecko": {
-      "id": "urlbar-nudges-experiment@shield.mozilla.org",
+      "id": "urlbar-tips@shield.mozilla.org",
       "strict_min_version": "71"
     }
   },
   "browser_specific_settings": {
     "gecko": {
-      "id": "urlbar-nudges-experiment@shield.mozilla.org",
+      "id": "urlbar-tips@shield.mozilla.org",
       "strict_min_version": "71"
     }
   },

--- a/tests/tests/browser/browser.ini
+++ b/tests/tests/browser/browser.ini
@@ -5,7 +5,7 @@
 [DEFAULT]
 support-files =
   head.js
-  urlbar_nudges_experiment-1.0.0.zip
+  urlbar_tips-1.0.0.zip
 
-[browser_nudges_homepage.js]
+[browser_searchHomepage.js]
 [browser_test.js]

--- a/tests/tests/browser/browser_searchHomepage.js
+++ b/tests/tests/browser/browser_searchHomepage.js
@@ -4,7 +4,7 @@
 "use strict";
 
 // The path of the add-on file relative to `getTestFilePath`.
-const ADDON_PATH = "urlbar_nudges_experiment-1.0.0.zip";
+const ADDON_PATH = "urlbar_tips-1.0.0.zip";
 
 // Use SIGNEDSTATE_MISSING when testing an unsigned, in-development version of
 // the add-on and SIGNEDSTATE_PRIVILEGED when testing the production add-on.

--- a/tests/tests/browser/browser_test.js
+++ b/tests/tests/browser/browser_test.js
@@ -11,7 +11,7 @@ XPCOMUtils.defineLazyModuleGetters(this, {
 });
 
 // The path of the add-on file relative to `getTestFilePath`.
-const ADDON_PATH = "urlbar_nudges_experiment-1.0.0.zip";
+const ADDON_PATH = "urlbar_tips-1.0.0.zip";
 
 // Use SIGNEDSTATE_MISSING when testing an unsigned, in-development version of
 // the add-on and SIGNEDSTATE_PRIVILEGED when testing the production add-on.


### PR DESCRIPTION
I talked with Verdi today, and he prefers "tip" to "nudge". He
doesn't want "nudge" to appear in user-facing text. That includes
the add-on name and ID, but I changed everything, even in code,
for consistency. I'll also rename this repo.