### PR TITLE
Bug 1590535 - Update background.js and add end-to-end test.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -38,7 +38,12 @@ const LAST_UPDATE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
 // Our browser.urlbar provider name.
 const URLBAR_PROVIDER_NAME = "tips";
 
-// storage[STORAGE_KEY_SHOWN_COUNT] is the shown count.
+// Telemetry names.
+const TELEMETRY_SCALARS_NAME = "urlbarTipsExperiment";
+const TELEMETRY_SCALARS_SHOWN_COUNT_NAME = `${TELEMETRY_SCALARS_NAME}.tipShownCount`;
+
+// We store in browser.storage.local the number of times we've shown a tip
+// across all sessions.
 const STORAGE_KEY_SHOWN_COUNT = "tipsShownCount";
 
 // The current study branch.
@@ -50,8 +55,7 @@ let currentTip = TIPS.NONE;
 // Whether we've shown a tip in the current session.
 let showedTipInCurrentSession = false;
 
-// Our copy of browser.storage.local.  We store the number of times we've shown
-// a tip across all sessions.
+// Our copy of browser.storage.local.
 let storage;
 
 /**
@@ -146,7 +150,7 @@ async function maybeShowTipForTab(tabID) {
 
   // Update shown-count telemetry.
   browser.telemetry.keyedScalarAdd(
-    "urlbarTipsExperiment.tipShownCount",
+    TELEMETRY_SCALARS_SHOWN_COUNT_NAME,
     telemetryKey,
     1
   );
@@ -297,7 +301,7 @@ async function enroll() {
   await browser.experiments.urlbar.engagementTelemetry.set({ value: true });
 
   // Register scalar telemetry.  We increment a keyed scalar when we show a tip.
-  browser.telemetry.registerScalars("urlbarTipsExperiment", {
+  browser.telemetry.registerScalars(TELEMETRY_SCALARS_NAME, {
     tipShownCount: {
       kind: "count",
       keyed: true,

--- a/src/background.js
+++ b/src/background.js
@@ -252,10 +252,7 @@ async function unenroll() {
   await browser.urlbar.onResultPicked.removeListener(onResultPicked);
   await browser.webNavigation.onBeforeNavigate.removeListener(onBeforeNavigate);
   await browser.windows.onFocusChanged.removeListener(onWindowFocusChanged);
-
-  //XXXadw see XXX below
-  await browser.urlbar.engagementTelemetry.clear({});
-
+  await browser.experiments.urlbar.engagementTelemetry.clear({});
   sendTestMessage("unenrolled");
 }
 
@@ -297,9 +294,7 @@ async function enroll() {
   await browser.windows.onFocusChanged.addListener(onWindowFocusChanged);
 
   // Enable urlbar engagement event telemetry.
-  //XXXadw need marco's api again?  did shane's bugs fix this?  see also
-  // browser.telemetry.setEventRecordingEnabled -- can use?
-  await browser.urlbar.engagementTelemetry.set({ value: true });
+  await browser.experiments.urlbar.engagementTelemetry.set({ value: true });
 
   // Register scalar telemetry.  We increment a keyed scalar when we show a tip.
   browser.telemetry.registerScalars("urlbarTipsExperiment", {

--- a/src/background.js
+++ b/src/background.js
@@ -242,6 +242,7 @@ function onWindowFocusChanged() {
  * Resets all the state we set on enrollment in the study.
  */
 async function unenroll() {
+  await browser.experiments.urlbar.engagementTelemetry.clear({});
   await browser.tabs.onActivated.removeListener(onTabActivated);
   await browser.webNavigation.onCompleted.removeListener(onWebNavigation);
   await browser.urlbar.onBehaviorRequested.removeListener(onBehaviorRequested);
@@ -249,7 +250,6 @@ async function unenroll() {
   await browser.urlbar.onResultPicked.removeListener(onResultPicked);
   await browser.webNavigation.onBeforeNavigate.removeListener(onBeforeNavigate);
   await browser.windows.onFocusChanged.removeListener(onWindowFocusChanged);
-  await browser.experiments.urlbar.engagementTelemetry.clear({});
   sendTestMessage("unenrolled");
 }
 

--- a/src/background.js
+++ b/src/background.js
@@ -12,9 +12,9 @@ const BRANCHES = {
 
 // The possible tips to show.
 const TIPS = {
-  NONE: 0,
-  ONBOARD: 1,
-  REDIRECT: 2,
+  NONE: "",
+  ONBOARD: "onboard",
+  REDIRECT: "redirect",
 };
 
 // Maps engine names to their homepages.  We show the redirect tip on these.
@@ -126,15 +126,12 @@ async function maybeShowTipForTab(tabID) {
 
   // Determine which tip we should show for the tab.
   let tip;
-  let telemetryKey;
   let isNewtab = ["about:newtab", "about:home"].includes(tab.url);
   let isSearchHomepage = !isNewtab && (await isDefaultEngineHomepage(tab.url));
   if (isNewtab) {
     tip = TIPS.ONBOARD;
-    telemetryKey = "onboard";
   } else if (isSearchHomepage) {
     tip = TIPS.REDIRECT;
-    telemetryKey = "redirect";
   } else {
     // No tip.
     return;
@@ -149,11 +146,7 @@ async function maybeShowTipForTab(tabID) {
   await browser.storage.local.set(storage);
 
   // Update shown-count telemetry.
-  browser.telemetry.keyedScalarAdd(
-    TELEMETRY_SCALARS_SHOWN_COUNT_NAME,
-    telemetryKey,
-    1
-  );
+  browser.telemetry.keyedScalarAdd(TELEMETRY_SCALARS_SHOWN_COUNT_NAME, tip, 1);
 
   if (studyBranch == BRANCHES.TREATMENT) {
     // Start a search.  Our browser.urlbar.onBehaviorRequested and

--- a/src/background.js
+++ b/src/background.js
@@ -4,62 +4,311 @@
 
 "use strict";
 
+// The possible study branches.
 const BRANCHES = {
   CONTROL: "control",
   TREATMENT: "treatment",
 };
 
-// The example.com domains are for testing. Consumers of isDefaultEngineHomepage
-// should check that the active hostname is not example.com before displaying
-// a search tip.
+// The possible tips to show.
+const TIPS = {
+  NONE: 0,
+  ONBOARD: 1,
+  REDIRECT: 2,
+};
+
+// Maps engine names to their homepages.  We show the redirect tip on these.
 const SUPPORTED_ENGINES = new Map([
-  ["Google", ["www.google.com", "www.google.com/webhp", "example.com/google"]],
-  ["Bing", ["www.bing.com", "example.com/bing"]],
-  ["DuckDuckGo", ["duckduckgo.com", "start.duckduckgo.com", "example.com/ddg"]],
+  ["Google", ["www.google.com", "www.google.com/webhp"]],
+  ["Bing", ["www.bing.com"]],
+  ["DuckDuckGo", ["duckduckgo.com", "start.duckduckgo.com"]],
 ]);
 
+// The maximum number of times we'll show a tip across all sessions.
+const MAX_SHOWN_COUNT = 4;
+
+// Amount of time to wait before showing a tip after selecting a tab or
+// navigating to a page where we should show a tip.
+const SHOW_TIP_DELAY_MS = 200;
+
+// We won't show a tip if the browser has been updated in the past
+// LAST_UPDATE_THRESHOLD_MS.
+const LAST_UPDATE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+
+// Our browser.urlbar provider name.
+const URLBAR_PROVIDER_NAME = "tips";
+
+// storage[STORAGE_KEY_SHOWN_COUNT] is the shown count.
+const STORAGE_KEY_SHOWN_COUNT = "tipsShownCount";
+
+// The current study branch.
+let studyBranch;
+
+// The tip we should currently show.
+let currentTip = TIPS.NONE;
+
+// Whether we've shown a tip in the current session.
+let showedTipInCurrentSession = false;
+
+// Our copy of browser.storage.local.  We store the number of times we've shown
+// a tip across all sessions.
+let storage;
+
 /**
- * Logs a debug message, which the test harness interprets as a message the
- * add-on is sending to the test.  See head.js for info.
- *
- * @param {string} msg
- *   The message.
+ * browser.tabs.onTabActivated listener.  Checks to see whether we should show a
+ * tip.
  */
-function sendTestMessage(msg) {
-  console.debug(browser.runtime.id, msg);
+function onTabActivated(info) {
+  maybeShowTipForTab(info.tabId);
+}
+
+/**
+ * browser.webNavigation.onCompleted listener.  Called when a page has finished
+ * loading.  Checks to see whether we should show a tip.
+ */
+async function onWebNavigation(details) {
+  // frameId == 0 for top-level loads.  We also exclude about:newtab because
+  // sometimes when a new tab is opened, this function is called *while*
+  // onTabActivated/maybeShowTipForTab are in the middle of running (but not
+  // always), and that causes no tip or an incorrect tip to be shown (at least
+  // during the test).  So we'll capture new tabs by onTabActivated only.
+  if (details.frameId == 0 && details.url != "about:newtab") {
+    let tab = await browser.tabs.get(details.tabId);
+    if (tab.active) {
+      maybeShowTipForTab(details.tabId);
+    }
+  }
+}
+
+/**
+ * Determines whether we should show a tip for the current tab.  Sets currentTip
+ * and calls browser.urlbar.search as appropriate.  Once this calls search, our
+ * browser.urlbar.onBehaviorRequested and browser.urlbar.onResultsRequested
+ * listeners take it from there.
+ *
+ * @param {number} tabID
+ *   The ID of the current tab.
+ */
+async function maybeShowTipForTab(tabID) {
+  let tab = await browser.tabs.get(tabID);
+
+  // We show only one tip per session, so if we've shown one already, stop.
+  if (showedTipInCurrentSession) {
+    return;
+  }
+
+  // Get the number of times we've shown a tip over all sessions.  If it's the
+  // max, don't show it again.
+  if (!storage) {
+    storage = await browser.storage.local.get(STORAGE_KEY_SHOWN_COUNT);
+    if (!(STORAGE_KEY_SHOWN_COUNT in storage)) {
+      storage[STORAGE_KEY_SHOWN_COUNT] = 0;
+    }
+  }
+  if (storage[STORAGE_KEY_SHOWN_COUNT] >= MAX_SHOWN_COUNT) {
+    return;
+  }
+
+  // Don't show a tip if the browser is already showing some other notification.
+  if (await browser.experiments.urlbar.isBrowserShowingNotification()) {
+    return;
+  }
+
+  // Don't show a tip if the browser has been updated recently.
+  let date = await browser.experiments.urlbar.lastBrowserUpdateDate();
+  if (Date.now() - date <= LAST_UPDATE_THRESHOLD_MS) {
+    return;
+  }
+
+  // Determine which tip we should show for the tab.
+  let tip;
+  let telemetryKey;
+  let isNewtab = ["about:newtab", "about:home"].includes(tab.url);
+  let isSearchHomepage = !isNewtab && (await isDefaultEngineHomepage(tab.url));
+  if (isNewtab) {
+    tip = TIPS.ONBOARD;
+    telemetryKey = "onboard";
+  } else if (isSearchHomepage) {
+    tip = TIPS.REDIRECT;
+    telemetryKey = "redirect";
+  } else {
+    // No tip.
+    return;
+  }
+
+  // At this point, we're showing a tip.
+
+  showedTipInCurrentSession = true;
+
+  // Store the new shown count.
+  storage[STORAGE_KEY_SHOWN_COUNT]++;
+  await browser.storage.local.set(storage);
+
+  // Update shown-count telemetry.
+  browser.telemetry.keyedScalarAdd(
+    "urlbarTipsExperiment.tipShownCount",
+    telemetryKey,
+    1
+  );
+
+  if (studyBranch == BRANCHES.TREATMENT) {
+    // Start a search.  Our browser.urlbar.onBehaviorRequested and
+    // browser.urlbar.onResultsRequested listeners will be called.  We do this
+    // on a timeout because sometimes urlbar.value will be set *after* our
+    // search call (due to an onLocationChange), and we want it to remain empty.
+    setTimeout(() => {
+      currentTip = tip;
+      browser.urlbar.search("", { focus: tip == TIPS.ONBOARD });
+    }, SHOW_TIP_DELAY_MS);
+  }
+}
+
+/**
+ * browser.urlbar.onBehaviorRequested listener.
+ */
+async function onBehaviorRequested(query) {
+  return currentTip ? "restricting" : "inactive";
+}
+
+/**
+ * browser.urlbar.onResultsRequested listener.
+ */
+async function onResultsRequested(query) {
+  let tip = currentTip;
+  currentTip = TIPS.NONE;
+
+  let engines = await browser.search.get();
+  let defaultEngine = engines.find(engine => engine.isDefault);
+
+  let result = {
+    type: "tip",
+    source: "local",
+    heuristic: true,
+    payload: {
+      icon: defaultEngine.favIconUrl,
+      buttonText: "Okay, Got It",
+    },
+  };
+
+  switch (tip) {
+    case TIPS.ONBOARD:
+      result.payload.text =
+        `Type less, find more: Search ${defaultEngine.name} ` +
+        `right from your address bar.`;
+      break;
+    case TIPS.REDIRECT:
+      result.payload.text =
+        `Start your search here to see suggestions from ` +
+        `${defaultEngine.name} and your browsing history.`;
+      break;
+  }
+
+  return [result];
+}
+
+/**
+ * browser.urlbar.onResultPicked listener.  Called when a tip button is picked.
+ */
+async function onResultPicked(payload) {
+  browser.urlbar.focus();
+
+  // The user clicked the "Okay, Got It" button.  We shouldn't show a tip again
+  // in any session.  Set the shown count to the max.
+  storage[STORAGE_KEY_SHOWN_COUNT] = MAX_SHOWN_COUNT;
+  await browser.storage.local.set(storage);
+}
+
+/**
+ * browser.webNavigation.onBeforeNavigate listener.  Called when a new
+ * navigation starts.  We use this to close the urlbar view, which is necessary
+ * when the input isn't focused.
+ */
+async function onBeforeNavigate(details) {
+  // frameId == 0 for top-level loads.
+  if (details.frameId == 0) {
+    let tab = await browser.tabs.get(details.tabId);
+    if (tab.active) {
+      browser.urlbar.closeView();
+    }
+  }
+}
+
+/**
+ * browser.windows.onFocusChanged listener.  We use this to close the urlbar
+ * view, which is necessary when the input isn't focused.
+ */
+function onWindowFocusChanged() {
+  browser.urlbar.closeView();
 }
 
 /**
  * Resets all the state we set on enrollment in the study.
- *
- * @param {bool} isTreatmentBranch
- *   True if we were enrolled on the treatment branch, false if control.
  */
-async function unenroll(isTreatmentBranch) {
-  //XXX Handle unenrollment here.
+async function unenroll() {
+  await browser.tabs.onActivated.removeListener(onTabActivated);
+  await browser.webNavigation.onCompleted.removeListener(onWebNavigation);
+  await browser.urlbar.onBehaviorRequested.removeListener(onBehaviorRequested);
+  await browser.urlbar.onResultsRequested.removeListener(onResultsRequested);
+  await browser.urlbar.onResultPicked.removeListener(onResultPicked);
+  await browser.webNavigation.onBeforeNavigate.removeListener(onBeforeNavigate);
+  await browser.windows.onFocusChanged.removeListener(onWindowFocusChanged);
+
+  //XXXadw see XXX below
+  await browser.urlbar.engagementTelemetry.clear({});
 
   sendTestMessage("unenrolled");
 }
 
 /**
  * Sets up all appropriate state for enrollment in the study.
- *
- * @param {bool} isTreatmentBranch
- *   True if we are enrolling on the treatment branch, false if control.
  */
-async function enroll(isTreatmentBranch) {
+async function enroll() {
   await browser.normandyAddonStudy.onUnenroll.addListener(async () => {
-    await unenroll(isTreatmentBranch);
+    await unenroll();
   });
 
+  // Listen for tab selection.
+  await browser.tabs.onActivated.addListener(onTabActivated);
+
+  // Listen for page loads.
+  await browser.webNavigation.onCompleted.addListener(onWebNavigation);
+
+  // Add urlbar listeners.
+  await browser.urlbar.onBehaviorRequested.addListener(
+    onBehaviorRequested,
+    URLBAR_PROVIDER_NAME
+  );
+  await browser.urlbar.onResultsRequested.addListener(
+    onResultsRequested,
+    URLBAR_PROVIDER_NAME
+  );
+  await browser.urlbar.onResultPicked.addListener(
+    onResultPicked,
+    URLBAR_PROVIDER_NAME
+  );
+
+  // When the urlbar is blurred, it automatically closes the view.  For the
+  // redirect tip, we open the view without focusing the urlbar, which means
+  // that it will remain open in more cases than usual.  The urlbar also closes
+  // the view when the user clicks outside the view and when tabs are selected.
+  // We need to handle when navigation happens (without a click) and when the
+  // window focus changes.
+  await browser.webNavigation.onBeforeNavigate.addListener(onBeforeNavigate);
+  await browser.windows.onFocusChanged.addListener(onWindowFocusChanged);
+
   // Enable urlbar engagement event telemetry.
+  //XXXadw need marco's api again?  did shane's bugs fix this?  see also
+  // browser.telemetry.setEventRecordingEnabled -- can use?
   await browser.urlbar.engagementTelemetry.set({ value: true });
 
-  //XXX Handle enrollment here.
-
-  if (isTreatmentBranch) {
-    //XXX Handle enrollment in the treatment branch here.
-  }
+  // Register scalar telemetry.  We increment a keyed scalar when we show a tip.
+  browser.telemetry.registerScalars("urlbarTipsExperiment", {
+    tipShownCount: {
+      kind: "count",
+      keyed: true,
+      record_on_release: true,
+    },
+  });
 
   sendTestMessage("enrolled");
 }
@@ -88,7 +337,7 @@ async function isDefaultEngineHomepage(urlStr) {
   let url;
   try {
     url = new URL(urlStr);
-  } catch(e) {
+  } catch (e) {
     return false;
   }
   // Strip protocol, query parameters, and trailing slash.
@@ -98,6 +347,17 @@ async function isDefaultEngineHomepage(urlStr) {
   }
 
   return homepages.includes(urlStr);
+}
+
+/**
+ * Logs a debug message, which the test harness interprets as a message the
+ * add-on is sending to the test.  See head.js for info.
+ *
+ * @param {string} msg
+ *   The message.
+ */
+function sendTestMessage(msg) {
+  console.debug(browser.runtime.id, msg);
 }
 
 (async function main() {
@@ -116,7 +376,8 @@ async function isDefaultEngineHomepage(urlStr) {
   if (study) {
     // Sanity check the study.  This conditional should always be true.
     if (study.active && Object.values(BRANCHES).includes(study.branch)) {
-      await enroll(study.branch == BRANCHES.TREATMENT);
+      studyBranch = study.branch;
+      await enroll();
     }
     sendTestMessage("ready");
     return;
@@ -127,22 +388,9 @@ async function isDefaultEngineHomepage(urlStr) {
   installPromise.then(async isTemporaryInstall => {
     if (isTemporaryInstall) {
       console.debug("isTemporaryInstall");
-      await enroll(true);
+      studyBranch = BRANCHES.TREATMENT;
+      await enroll();
     }
     sendTestMessage("ready");
   });
 })();
-
-async function onTabUpdated(tabId, changeInfo, tabInfo) {
-  if (changeInfo.status != "complete") {
-    return;
-  }
-  await isDefaultEngineHomepage(tabInfo.url).then(function(isHomepage) {
-    sendTestMessage("Page is engine homepage: " + isHomepage);
-    if (isHomepage && new URL(tabInfo.url).hostname != "example.com") {
-      // TODO: Display tip.
-    }
-  });
-}
-
-browser.tabs.onUpdated.addListener(onTabUpdated);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,8 +18,11 @@
   "permissions": [
     "normandyAddonStudy",
     "search",
+    "storage",
     "tabs",
-    "urlbar"
+    "telemetry",
+    "urlbar",
+    "webNavigation"
   ],
   "background": {
     "scripts": [
@@ -27,5 +30,15 @@
     ]
   },
   "incognito": "spanning",
-  "hidden": true
+  "hidden": true,
+  "experiment_apis": {
+    "experiments_urlbar": {
+      "schema": "experiments/urlbar/schema.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "paths": [["experiments", "urlbar"]],
+        "script": "experiments/urlbar/api.js"
+      }
+    }
+  }
 }

--- a/tests/tests/browser/browser_test.js
+++ b/tests/tests/browser/browser_test.js
@@ -1,12 +1,16 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
+// End-to-end test.  This doesn't test the max-shown-count limit because it
+// requires restarting the browser.
+
 "use strict";
 
 XPCOMUtils.defineLazyModuleGetters(this, {
-  PlacesTestUtils: "resource://testing-common/PlacesTestUtils.jsm",
+  AppMenuNotifications: "resource://gre/modules/AppMenuNotifications.jsm",
+  HttpServer: "resource://testing-common/httpd.js",
+  ProfileAge: "resource://gre/modules/ProfileAge.jsm",
   UrlbarPrefs: "resource:///modules/UrlbarPrefs.jsm",
-  UrlbarProvidersManager: "resource:///modules/UrlbarProvidersManager.jsm",
   UrlbarTestUtils: "resource://testing-common/UrlbarTestUtils.jsm",
 });
 
@@ -18,97 +22,501 @@ const ADDON_PATH = "urlbar_tips-1.0.0.zip";
 const EXPECTED_ADDON_SIGNED_STATE = AddonManager.SIGNEDSTATE_MISSING;
 // const EXPECTED_ADDON_SIGNED_STATE = AddonManager.SIGNEDSTATE_PRIVILEGED;
 
-const CONTROL_BRANCH = "control";
-const TREATMENT_BRANCH = "treatment";
+const BRANCHES = {
+  CONTROL: "control",
+  TREATMENT: "treatment",
+};
 
-const EVENT_TELEMETRY_PREF = "eventTelemetry.enabled";
+// Should match the same const in background.js.
+const SHOW_TIP_DELAY_MS = 200;
 
-/**
- * Asserts that the browser UI has the treatment properly applied.
- *
- * @param {window} win
- *   The browser window to test.
- */
-async function assertAppliedTreatmentToUI(win = window) {
-  //XXX assertions here
-}
+// Should match the same const in background.js.
+const LAST_UPDATE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
 
-/**
- * Asserts that the browser UI does not have the treatment applied.
- *
- * @param {window} win
- *   The browser window to test.
- */
-async function assertNotAppliedTreatmentToUI(win = window) {
-  //XXX assertions here
-}
-
-/**
- * Asserts that everything is set up properly to reflect enrollment in the
- * study.
- *
- * @param {bool} isTreatmentBranch
- *   True if the enrolled branch is treatment and false if control.
- */
-async function assertEnrolled(isTreatmentBranch) {
-  Assert.equal(UrlbarPrefs.get(EVENT_TELEMETRY_PREF), true);
-  if (isTreatmentBranch) {
-    await assertAppliedTreatmentToUI();
-  } else {
-    await assertNotAppliedTreatmentToUI();
-  }
-}
-
-/**
- * Asserts that everything is set up properly to reflect no enrollment in the
- * study.
- */
-async function assertNotEnrolled() {
-  Assert.equal(UrlbarPrefs.get(EVENT_TELEMETRY_PREF), false);
-  await assertNotAppliedTreatmentToUI();
-}
+const TIPS = {
+  NONE: 0,
+  ONBOARD: 1,
+  REDIRECT: 2,
+};
 
 add_task(async function init() {
   await PlacesUtils.history.clear();
   await PlacesUtils.bookmarks.eraseEverything();
 
+  // Write an old profile age so tips are actually shown.
+  let age = await ProfileAge();
+  let originalTimes = age._times;
+  let date = Date.now() - LAST_UPDATE_THRESHOLD_MS - 30000;
+  age._times = { created: date, firstUse: date };
+  await age.writeTimes();
+
+  registerCleanupFunction(async () => {
+    let age = await ProfileAge();
+    age._times = originalTimes;
+    await age.writeTimes();
+  });
+
   await initAddonTest(ADDON_PATH, EXPECTED_ADDON_SIGNED_STATE);
 });
 
-add_task(async function treatment() {
-  await withStudy({ branch: TREATMENT_BRANCH }, async () => {
+// The onboarding tip should be shown on about:newtab.
+add_task(async function newtab() {
+  await withStudy({ branch: BRANCHES.TREATMENT }, async () => {
     await withAddon(async () => {
-      await assertEnrolled(true);
+      await checkTab(window, "about:newtab", TIPS.ONBOARD);
     });
   });
 });
 
-add_task(async function control() {
-  await withStudy({ branch: CONTROL_BRANCH }, async () => {
+// The onboarding tip should be shown on about:home.
+add_task(async function home() {
+  await withStudy({ branch: BRANCHES.TREATMENT }, async () => {
     await withAddon(async () => {
-      await assertEnrolled(false);
+      await checkTab(window, "about:home", TIPS.ONBOARD);
+    });
+  });
+});
+
+// The redirect tip should be shown for www.google.com when it's the default
+// engine.
+add_task(async function google() {
+  await setDefaultEngine("Google");
+  await withStudy({ branch: BRANCHES.TREATMENT }, async () => {
+    await withAddon(async () => {
+      await withDNSRedirect("www.google.com", "/", async url => {
+        await checkTab(window, url, TIPS.REDIRECT);
+      });
+    });
+  });
+});
+
+// The redirect tip should be shown for www.google.com/webhp when it's the
+// default engine.
+add_task(async function googleWebhp() {
+  await setDefaultEngine("Google");
+  await withStudy({ branch: BRANCHES.TREATMENT }, async () => {
+    await withAddon(async () => {
+      await withDNSRedirect("www.google.com", "/webhp", async url => {
+        await checkTab(window, url, TIPS.REDIRECT);
+      });
+    });
+  });
+});
+
+// The redirect tip should not be shown for www.google.com when it's not the
+// default engine.
+add_task(async function googleNotDefault() {
+  await setDefaultEngine("Bing");
+  await withStudy({ branch: BRANCHES.TREATMENT }, async () => {
+    await withAddon(async () => {
+      await withDNSRedirect("www.google.com", "/", async url => {
+        await checkTab(window, url, TIPS.NONE);
+      });
+    });
+  });
+});
+
+// The redirect tip should not be shown for www.google.com/webhp when it's not
+// the default engine.
+add_task(async function googleWebhpNotDefault() {
+  await setDefaultEngine("Bing");
+  await withStudy({ branch: BRANCHES.TREATMENT }, async () => {
+    await withAddon(async () => {
+      await withDNSRedirect("www.google.com", "/webhp", async url => {
+        await checkTab(window, url, TIPS.NONE);
+      });
+    });
+  });
+});
+
+// The redirect tip should be shown for www.bing.com when it's the default
+// engine.
+add_task(async function bing() {
+  await setDefaultEngine("Bing");
+  await withStudy({ branch: BRANCHES.TREATMENT }, async () => {
+    await withAddon(async () => {
+      await withDNSRedirect("www.bing.com", "/", async url => {
+        await checkTab(window, url, TIPS.REDIRECT);
+      });
+    });
+  });
+});
+
+// The redirect tip should not be shown for www.bing.com when it's not the
+// default engine.
+add_task(async function bingNotDefault() {
+  await setDefaultEngine("Google");
+  await withStudy({ branch: BRANCHES.TREATMENT }, async () => {
+    await withAddon(async () => {
+      await withDNSRedirect("www.bing.com", "/", async url => {
+        await checkTab(window, url, TIPS.NONE);
+      });
+    });
+  });
+});
+
+// The redirect tip should be shown for duckduckgo.com when it's the default
+// engine.
+add_task(async function ddg() {
+  await setDefaultEngine("DuckDuckGo");
+  await withStudy({ branch: BRANCHES.TREATMENT }, async () => {
+    await withAddon(async () => {
+      await withDNSRedirect("duckduckgo.com", "/", async url => {
+        await checkTab(window, url, TIPS.REDIRECT);
+      });
+    });
+  });
+});
+
+// The redirect tip should be shown for start.duckduckgo.com when it's the
+// default engine.
+add_task(async function ddgStart() {
+  await setDefaultEngine("DuckDuckGo");
+  await withStudy({ branch: BRANCHES.TREATMENT }, async () => {
+    await withAddon(async () => {
+      await withDNSRedirect("start.duckduckgo.com", "/", async url => {
+        await checkTab(window, url, TIPS.REDIRECT);
+      });
+    });
+  });
+});
+
+// The redirect tip should not be shown for duckduckgo.com when it's not the
+// default engine.
+add_task(async function ddgNotDefault() {
+  await setDefaultEngine("Google");
+  await withStudy({ branch: BRANCHES.TREATMENT }, async () => {
+    await withAddon(async () => {
+      await withDNSRedirect("duckduckgo.com", "/", async url => {
+        await checkTab(window, url, TIPS.NONE);
+      });
+    });
+  });
+});
+
+// The redirect tip should not be shown for start.duckduckgo.com when it's not
+// the default engine.
+add_task(async function ddgStartNotDefault() {
+  await setDefaultEngine("Google");
+  await withStudy({ branch: BRANCHES.TREATMENT }, async () => {
+    await withAddon(async () => {
+      await withDNSRedirect("start.duckduckgo.com", "/", async url => {
+        await checkTab(window, url, TIPS.NONE);
+      });
+    });
+  });
+});
+
+// The redirect tip should not be shown on a non-engine page.
+add_task(async function nonEnginePage() {
+  await withStudy({ branch: BRANCHES.TREATMENT }, async () => {
+    await withAddon(async () => {
+      await checkTab(window, "http://example.com/", TIPS.NONE);
+    });
+  });
+});
+
+// Tips should be shown at most once per session.
+add_task(async function oncePerSession() {
+  await setDefaultEngine("Google");
+  await withStudy({ branch: BRANCHES.TREATMENT }, async () => {
+    await withAddon(async () => {
+      await checkTab(window, "about:newtab", TIPS.ONBOARD);
+      await checkTab(window, "about:newtab", TIPS.NONE);
+      await withDNSRedirect("www.google.com", "/", async url => {
+        await checkTab(window, url, TIPS.NONE);
+      });
+    });
+  });
+});
+
+// The tip shouldn't be shown when there's another notification present.
+add_task(async function notification() {
+  await withStudy({ branch: BRANCHES.TREATMENT }, async () => {
+    await withAddon(async () => {
+      await BrowserTestUtils.withNewTab("about:blank", async () => {
+        let box = gBrowser.getNotificationBox();
+        let note = box.appendNotification(
+          "Test",
+          "urlbar-test",
+          null,
+          box.PRIORITY_INFO_HIGH,
+          null,
+          null,
+          null
+        );
+        // Give it a big persistence so it doesn't go away on page load.
+        note.persistence = 100;
+        await withDNSRedirect("www.google.com", "/", async url => {
+          await BrowserTestUtils.loadURI(gBrowser.selectedBrowser, url);
+          await BrowserTestUtils.browserLoaded(gBrowser.selectedBrowser);
+          await checkTip(window, TIPS.NONE);
+          box.removeNotification(note, true);
+        });
+      });
+    });
+  });
+});
+
+// The tip should be shown when switching to a tab where it should be shown.
+add_task(async function tabSwitch() {
+  await withStudy({ branch: BRANCHES.TREATMENT }, async () => {
+    await withAddon(async () => {
+      let tab = BrowserTestUtils.addTab(gBrowser, "about:newtab");
+      await BrowserTestUtils.switchTab(gBrowser, tab);
+      await checkTip(window, TIPS.ONBOARD);
+      BrowserTestUtils.removeTab(tab);
+    });
+  });
+});
+
+// Checks engagement event telemetry and experiment telemetry after triggering
+// the onboard tip on the treatment branch.  We have a separate comprehensive
+// test in the tree for engagement event telemetry, so we don't test everything
+// here.  We only make sure that it's recorded.
+add_task(async function telemetryTreatmentOnboard() {
+  Services.telemetry.clearScalars();
+  Services.telemetry.clearEvents();
+  await withStudy({ branch: BRANCHES.TREATMENT }, async () => {
+    await withAddon(async () => {
+      let tab = await BrowserTestUtils.openNewForegroundTab({
+        gBrowser,
+        url: "about:newtab",
+        waitForLoad: false,
+      });
+
+      await checkTip(window, TIPS.ONBOARD, false);
+
+      // Pick the tip button by pressing enter.  The tip is the heuristic and
+      // the button is preselected, which is why this should work.
+      await UrlbarTestUtils.promisePopupClose(window, () => {
+        EventUtils.synthesizeKey("KEY_Enter");
+      });
+
+      BrowserTestUtils.removeTab(tab);
+
+      TelemetryTestUtils.assertKeyedScalar(
+        TelemetryTestUtils.getProcessScalars("dynamic", true),
+        "urlbarTipsExperiment.tipShownCount",
+        "onboard",
+        1
+      );
+
+      TelemetryTestUtils.assertEvents([
+        {
+          category: "urlbar",
+          method: "engagement",
+          object: "enter",
+          value: "typed",
+          extra: {
+            elapsed: val => parseInt(val) > 0,
+            numChars: "0",
+            selIndex: "0",
+            selType: "tip",
+          },
+        },
+      ]);
+    });
+  });
+});
+
+// Checks engagement event telemetry and experiment telemetry after triggering
+// the redirect tip on the treatment branch.
+add_task(async function telemetryTreatmentRedirect() {
+  await setDefaultEngine("Google");
+  Services.telemetry.clearScalars();
+  Services.telemetry.clearEvents();
+  await withStudy({ branch: BRANCHES.TREATMENT }, async () => {
+    await withAddon(async () => {
+      await withDNSRedirect("www.google.com", "/", async url => {
+        let tab = await BrowserTestUtils.openNewForegroundTab({
+          gBrowser,
+          url,
+        });
+
+        await checkTip(window, TIPS.REDIRECT, false);
+
+        // Click the tip button.
+        await UrlbarTestUtils.promisePopupClose(window, () => {
+          EventUtils.synthesizeMouseAtCenter(gURLBar.view.selectedElement, {});
+        });
+
+        BrowserTestUtils.removeTab(tab);
+
+        TelemetryTestUtils.assertKeyedScalar(
+          TelemetryTestUtils.getProcessScalars("dynamic", true),
+          "urlbarTipsExperiment.tipShownCount",
+          "redirect",
+          1
+        );
+
+        TelemetryTestUtils.assertEvents([
+          {
+            category: "urlbar",
+            method: "engagement",
+            object: "click",
+            value: "typed",
+            extra: {
+              elapsed: val => parseInt(val) > 0,
+              numChars: "0",
+              selIndex: "0",
+              selType: "tip",
+            },
+          },
+        ]);
+      });
+    });
+  });
+});
+
+// Checks engagement event telemetry and experiment telemetry on the control
+// branch after the onboard tip would have been shown.
+add_task(async function telemetryControlOnboard() {
+  Services.telemetry.clearScalars();
+  Services.telemetry.clearEvents();
+  await withStudy({ branch: BRANCHES.CONTROL }, async () => {
+    await withAddon(async () => {
+      let tab = await BrowserTestUtils.openNewForegroundTab({
+        gBrowser,
+        url: "about:newtab",
+        waitForLoad: false,
+      });
+      await checkTip(window, TIPS.NONE);
+      BrowserTestUtils.removeTab(tab);
+
+      // Shown-count telemetry should still be incremented.
+      TelemetryTestUtils.assertKeyedScalar(
+        TelemetryTestUtils.getProcessScalars("dynamic", true),
+        "urlbarTipsExperiment.tipShownCount",
+        "onboard",
+        1
+      );
+
+      // Trigger an abandonment event just to make sure engagement event
+      // telemetry is recorded on the control branch.
+      await UrlbarTestUtils.promiseAutocompleteResultPopup({
+        window,
+        value: "test",
+        waitForFocus,
+        fireInputEvent: true,
+      });
+      await UrlbarTestUtils.promisePopupClose(window, () => {
+        gURLBar.blur();
+      });
+      TelemetryTestUtils.assertEvents([
+        {
+          category: "urlbar",
+          method: "abandonment",
+          object: "blur",
+          value: "typed",
+          extra: {
+            elapsed: val => parseInt(val) > 0,
+            numChars: "4",
+          },
+        },
+      ]);
+    });
+  });
+});
+
+// Checks engagement event telemetry and experiment telemetry on the control
+// branch after the redirect tip would have been shown.
+add_task(async function telemetryControlRedirect() {
+  Services.telemetry.clearScalars();
+  Services.telemetry.clearEvents();
+  await withStudy({ branch: BRANCHES.CONTROL }, async () => {
+    await withAddon(async () => {
+      await withDNSRedirect("www.google.com", "/", async url => {
+        let tab = await BrowserTestUtils.openNewForegroundTab({
+          gBrowser,
+          url,
+        });
+        await checkTip(window, TIPS.NONE);
+        BrowserTestUtils.removeTab(tab);
+
+        // Shown-count telemetry should still be incremented.
+        TelemetryTestUtils.assertKeyedScalar(
+          TelemetryTestUtils.getProcessScalars("dynamic", true),
+          "urlbarTipsExperiment.tipShownCount",
+          "redirect",
+          1
+        );
+
+        // Trigger an abandonment event just to make sure engagement event
+        // telemetry is recorded on the control branch.
+        await UrlbarTestUtils.promiseAutocompleteResultPopup({
+          window,
+          value: "test",
+          waitForFocus,
+          fireInputEvent: true,
+        });
+        await UrlbarTestUtils.promisePopupClose(window, () => {
+          gURLBar.blur();
+        });
+        TelemetryTestUtils.assertEvents([
+          {
+            category: "urlbar",
+            method: "abandonment",
+            object: "blur",
+            value: "typed",
+            extra: {
+              elapsed: val => parseInt(val) > 0,
+              numChars: "4",
+            },
+          },
+        ]);
+      });
+    });
+  });
+});
+
+// The onboarding tip shouldn't be shown on the control branch.
+add_task(async function controlNewtab() {
+  await withStudy({ branch: BRANCHES.CONTROL }, async () => {
+    await withAddon(async () => {
+      await checkTab(window, "about:newtab", TIPS.NONE);
+    });
+  });
+});
+
+// The onboarding tip shouldn't be shown on about:home on the control branch.
+add_task(async function controlHome() {
+  await withStudy({ branch: BRANCHES.CONTROL }, async () => {
+    await withAddon(async () => {
+      await checkTab(window, "about:home", TIPS.NONE);
+    });
+  });
+});
+
+// The redirect tip shouldn't be shown for www.google.com on the control branch.
+add_task(async function controlGoogle() {
+  await setDefaultEngine("Google");
+  await withStudy({ branch: BRANCHES.CONTROL }, async () => {
+    await withAddon(async () => {
+      await withDNSRedirect("www.google.com", "/", async url => {
+        await checkTab(window, url, TIPS.NONE);
+      });
     });
   });
 });
 
 add_task(async function unenrollAfterInstall() {
-  await withStudy({ branch: TREATMENT_BRANCH }, async study => {
+  await withStudy({ branch: BRANCHES.TREATMENT }, async study => {
     await withAddon(async () => {
-      await assertEnrolled(true);
       await Promise.all([
         awaitAddonMessage("unenrolled"),
         AddonStudies.markAsEnded(study),
       ]);
-      await assertNotEnrolled();
+      await checkTab(window, "about:newtab", TIPS.NONE);
     });
   });
 });
 
 add_task(async function unenrollBeforeInstall() {
-  await withStudy({ branch: TREATMENT_BRANCH }, async study => {
+  await withStudy({ branch: BRANCHES.TREATMENT }, async study => {
     await AddonStudies.markAsEnded(study);
     await withAddon(async () => {
-      await assertNotEnrolled();
+      await checkTab(window, "about:newtab", TIPS.NONE);
     });
   });
 });
@@ -116,7 +524,7 @@ add_task(async function unenrollBeforeInstall() {
 add_task(async function noBranch() {
   await withStudy({}, async () => {
     await withAddon(async () => {
-      await assertNotEnrolled();
+      await checkTab(window, "about:newtab", TIPS.NONE);
     });
   });
 });
@@ -124,95 +532,120 @@ add_task(async function noBranch() {
 add_task(async function unrecognizedBranch() {
   await withStudy({ branch: "bogus" }, async () => {
     await withAddon(async () => {
-      await assertNotEnrolled();
+      await checkTab(window, "about:newtab", TIPS.NONE);
     });
   });
 });
 
-add_task(async function noStudy() {
-  if (EXPECTED_ADDON_SIGNED_STATE == AddonManager.SIGNEDSTATE_MISSING) {
-    info("This test doesn't apply to an unsigned add-on, skipping.");
+async function checkTip(win, expectedTip, closeView = true) {
+  if (!expectedTip) {
+    // Wait a bit for the tip to not show up.
+    // eslint-disable-next-line mozilla/no-arbitrary-setTimeout
+    await new Promise(resolve => setTimeout(resolve, 3 * SHOW_TIP_DELAY_MS));
+    Assert.ok(!win.gURLBar.view.isOpen);
     return;
   }
-  await withAddon(async addon => {
-    await assertNotEnrolled();
-  });
-});
 
-add_task(async function unrelatedStudy() {
-  if (EXPECTED_ADDON_SIGNED_STATE == AddonManager.SIGNEDSTATE_MISSING) {
-    info("This test doesn't apply to an unsigned add-on, skipping.");
-    return;
+  // Wait for the view to open, and then check the tip result.
+  await UrlbarTestUtils.promisePopupOpen(win, () => {});
+  Assert.ok(true, "View opened");
+  Assert.equal(UrlbarTestUtils.getResultCount(win), 1);
+  let result = await UrlbarTestUtils.getDetailsOfResultAt(win, 0);
+  Assert.equal(result.type, UrlbarUtils.RESULT_TYPE.TIP);
+  Assert.ok(result.heuristic);
+  let name = Services.search.defaultEngine.name;
+  let title;
+  switch (expectedTip) {
+    case TIPS.ONBOARD:
+      title =
+        `Type less, find more: Search ${name} right from your ` +
+        `address bar.`;
+      break;
+    case TIPS.REDIRECT:
+      title =
+        `Start your search here to see suggestions from ${name} ` +
+        `and your browsing history.`;
+      break;
   }
-  await withStudy(
-    {
-      addonId: "someOtherAddon@mozilla.org",
-      branch: TREATMENT_BRANCH,
-    },
-    async () => {
-      await withAddon(async () => {
-        await assertNotEnrolled();
-      });
-    }
+  Assert.equal(result.displayed.title, title);
+  Assert.equal(
+    result.element.row._elements.get("tipButton").textContent,
+    `Okay, Got It`
   );
-});
+  Assert.ok(
+    BrowserTestUtils.is_hidden(result.element.row._elements.get("helpButton"))
+  );
 
-// Checks engagement event telemetry while enrolled in the study on the
-// treatment branch.  We have a separate comprehensive test in the tree for this
-// telemetry, so we don't test everything here.  We only make sure that the
-// telemetry is indeed recorded.
-add_task(async function telemetryTreatment() {
-  Services.telemetry.clearEvents();
-  await withStudy({ branch: TREATMENT_BRANCH }, async () => {
-    await withAddon(async () => {
-      //XXX Do whatever triggers the telemetry in your case.  Then for example:
-/*
-      TelemetryTestUtils.assertEvents([
-        {
-          category: "urlbar",
-          method: "engagement",
-          object: "click",
-          value: "topsites",
-          extra: {
-            elapsed: val => parseInt(val) > 0,
-            numChars: "0",
-            selIndex: "1",
-            selType: "history",
-          },
-        },
-      ]);
-*/
-    });
-  });
-});
+  if (closeView) {
+    await UrlbarTestUtils.promisePopupClose(win);
+  }
+}
 
-// Checks engagement event telemetry while enrolled in the study on the control
-// branch.
-add_task(async function telemetryControl() {
-  Services.telemetry.clearEvents();
-  await withStudy({ branch: CONTROL_BRANCH }, async () => {
-    await withAddon(async () => {
-      //XXX Do whatever triggers the telemetry in your case.  Then for example:
-/*
-      // This is actually the same telemetry that should have been recorded on
-      // the treatment branch.  (See the treatment-branch test above.)  We will
-      // be able to distinguish between treatment and control telemetry in the
-      // telemetry pings.
-      TelemetryTestUtils.assertEvents([
-        {
-          category: "urlbar",
-          method: "engagement",
-          object: "click",
-          value: "topsites",
-          extra: {
-            elapsed: val => parseInt(val) > 0,
-            numChars: "0",
-            selIndex: "1",
-            selType: "history",
-          },
-        },
-      ]);
-*/
-    });
+async function checkTab(win, url, expectedTip) {
+  // BrowserTestUtils.withNewTab always waits for tab load, which hangs on
+  // about:newtab for some reason, so don't use it.
+  let tab = await BrowserTestUtils.openNewForegroundTab({
+    gBrowser: win.gBrowser,
+    url,
+    waitForLoad: url != "about:newtab",
   });
-});
+  await checkTip(win, expectedTip);
+  BrowserTestUtils.removeTab(tab);
+}
+
+/**
+ * This lets us visit the www.google.com (for example) and have it redirect to
+ * our test HTTP server instead of visiting the actual site.
+ */
+async function withDNSRedirect(domain, path, callback) {
+  // Some domains have special security requirements, like www.bing.com.  We
+  // need to override them to successfully load them.  This part is adapted from
+  // testing/marionette/cert.js.
+  const certOverrideService = Cc[
+    "@mozilla.org/security/certoverride;1"
+  ].getService(Ci.nsICertOverrideService);
+  Services.prefs.setBoolPref(
+    "network.stricttransportsecurity.preloadlist",
+    false
+  );
+  Services.prefs.setIntPref("security.cert_pinning.enforcement_level", 0);
+  certOverrideService.setDisableAllSecurityChecksAndLetAttackersInterceptMyData(
+    true
+  );
+
+  // Now set network.dns.localDomains to redirect the domain to localhost and
+  // set up an HTTP server.
+  Services.prefs.setCharPref("network.dns.localDomains", domain);
+
+  let server = new HttpServer();
+  server.registerPathHandler(path, (req, resp) => {
+    resp.write(`Test! http://${domain}${path}`);
+  });
+  server.start(-1);
+  server.identity.setPrimary("http", domain, server.identity.primaryPort);
+  let url = `http://${domain}:${server.identity.primaryPort}${path}`;
+
+  await callback(url);
+
+  // Reset network.dns.localDomains and stop the server.
+  Services.prefs.clearUserPref("network.dns.localDomains");
+  await new Promise(resolve => server.stop(resolve));
+
+  // Reset the security stuff.
+  certOverrideService.setDisableAllSecurityChecksAndLetAttackersInterceptMyData(
+    false
+  );
+  Services.prefs.clearUserPref("network.stricttransportsecurity.preloadlist");
+  Services.prefs.clearUserPref("security.cert_pinning.enforcement_level");
+  const sss = Cc["@mozilla.org/ssservice;1"].getService(
+    Ci.nsISiteSecurityService
+  );
+  sss.clearAll();
+  sss.clearPreloads();
+}
+
+async function setDefaultEngine(name) {
+  let engine = (await Services.search.getEngines()).find(e => e.name == name);
+  Assert.ok(engine);
+  await Services.search.setDefault(engine);
+}

--- a/tests/tests/browser/browser_test.js
+++ b/tests/tests/browser/browser_test.js
@@ -27,11 +27,11 @@ const BRANCHES = {
   TREATMENT: "treatment",
 };
 
-// Should match the same const in background.js.
+// These should match the same consts in background.js.
 const SHOW_TIP_DELAY_MS = 200;
-
-// Should match the same const in background.js.
 const LAST_UPDATE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+const TELEMETRY_SCALARS_NAME = "urlbarTipsExperiment";
+const TELEMETRY_SCALARS_SHOWN_COUNT_NAME = `${TELEMETRY_SCALARS_NAME}.tipShownCount`;
 
 const TIPS = {
   NONE: 0,
@@ -297,7 +297,7 @@ add_task(async function telemetryTreatmentOnboard() {
 
       TelemetryTestUtils.assertKeyedScalar(
         TelemetryTestUtils.getProcessScalars("dynamic", true),
-        "urlbarTipsExperiment.tipShownCount",
+        TELEMETRY_SCALARS_SHOWN_COUNT_NAME,
         "onboard",
         1
       );
@@ -345,7 +345,7 @@ add_task(async function telemetryTreatmentRedirect() {
 
         TelemetryTestUtils.assertKeyedScalar(
           TelemetryTestUtils.getProcessScalars("dynamic", true),
-          "urlbarTipsExperiment.tipShownCount",
+          TELEMETRY_SCALARS_SHOWN_COUNT_NAME,
           "redirect",
           1
         );
@@ -387,7 +387,7 @@ add_task(async function telemetryControlOnboard() {
       // Shown-count telemetry should still be incremented.
       TelemetryTestUtils.assertKeyedScalar(
         TelemetryTestUtils.getProcessScalars("dynamic", true),
-        "urlbarTipsExperiment.tipShownCount",
+        TELEMETRY_SCALARS_SHOWN_COUNT_NAME,
         "onboard",
         1
       );
@@ -437,7 +437,7 @@ add_task(async function telemetryControlRedirect() {
         // Shown-count telemetry should still be incremented.
         TelemetryTestUtils.assertKeyedScalar(
           TelemetryTestUtils.getProcessScalars("dynamic", true),
-          "urlbarTipsExperiment.tipShownCount",
+          TELEMETRY_SCALARS_SHOWN_COUNT_NAME,
           "redirect",
           1
         );

--- a/tests/tests/browser/head.js
+++ b/tests/tests/browser/head.js
@@ -206,7 +206,7 @@ async function withAddon(callback) {
     "The add-on should have the expected signed state"
   );
 
-  await callback();
+  await callback(addon);
 
   // If `withStudy` was called and there's an active study, Normandy will
   // automatically end the study when it sees that the add-on has been


### PR DESCRIPTION
This is done and ready for review except for a question about the
engagement event telemetry pref, the one that caused us problems
in the top-sites experiment.  I need to look into whether we need
to use Marco's experiment API from top sites again or can rely on
changes that Shane made in the meantime.  But this is ready for
first review.