### PR TITLE
Bug 1598368 - Make the redirect tip not the heuristic result.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -180,7 +180,6 @@ async function onResultsRequested(query) {
   let result = {
     type: "tip",
     source: "local",
-    heuristic: true,
     payload: {
       icon: defaultEngine.favIconUrl,
       buttonText: "Okay, Got It",
@@ -189,11 +188,13 @@ async function onResultsRequested(query) {
 
   switch (tip) {
     case TIPS.ONBOARD:
+      result.heuristic = true;
       result.payload.text =
         `Type less, find more: Search ${defaultEngine.name} ` +
         `right from your address bar.`;
       break;
     case TIPS.REDIRECT:
+      result.heuristic = false;
       result.payload.text =
         `Start your search here to see suggestions from ` +
         `${defaultEngine.name} and your browsing history.`;

--- a/tests/tests/browser/browser.ini
+++ b/tests/tests/browser/browser.ini
@@ -5,7 +5,7 @@
 [DEFAULT]
 support-files =
   head.js
-  urlbar_tips-1.0.0.zip
+  ../urlbar_tips-1.0.0.zip
 
 [browser_searchHomepage.js]
 [browser_test.js]

--- a/tests/tests/browser/browser_searchHomepage.js
+++ b/tests/tests/browser/browser_searchHomepage.js
@@ -1,15 +1,7 @@
 /* Any copyright is dedicated to the Public Domain.
-* http://creativecommons.org/publicdomain/zero/1.0/ */
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 "use strict";
-
-// The path of the add-on file relative to `getTestFilePath`.
-const ADDON_PATH = "urlbar_tips-1.0.0.zip";
-
-// Use SIGNEDSTATE_MISSING when testing an unsigned, in-development version of
-// the add-on and SIGNEDSTATE_PRIVILEGED when testing the production add-on.
-const EXPECTED_ADDON_SIGNED_STATE = AddonManager.SIGNEDSTATE_MISSING;
-// const EXPECTED_ADDON_SIGNED_STATE = AddonManager.SIGNEDSTATE_PRIVILEGED;
 
 add_task(async function init() {
   let previousDefaultEngine = await Services.search.getDefault();

--- a/tests/tests/browser/head.js
+++ b/tests/tests/browser/head.js
@@ -16,6 +16,19 @@ XPCOMUtils.defineLazyModuleGetters(this, {
   TelemetryTestUtils: "resource://testing-common/TelemetryTestUtils.jsm",
 });
 
+// The path of the add-on file relative to `getTestFilePath`.
+const ADDON_PATH = "urlbar_tips-1.0.0.zip";
+
+// Use SIGNEDSTATE_MISSING when testing an unsigned, in-development version of
+// the add-on and SIGNEDSTATE_PRIVILEGED when testing the production add-on.
+const EXPECTED_ADDON_SIGNED_STATE = AddonManager.SIGNEDSTATE_MISSING;
+// const EXPECTED_ADDON_SIGNED_STATE = AddonManager.SIGNEDSTATE_PRIVILEGED;
+
+const BRANCHES = {
+  CONTROL: "control",
+  TREATMENT: "treatment",
+};
+
 AddonTestUtils.initMochitest(this);
 
 /**


### PR DESCRIPTION
This also:

* Updates the test, including to remove the active update and
  update history so that the test can run after the browser was
  updated (I hit this in my testing today)
* Makes the tests and head.js more consistent with my current
  work on the interventions repo and the way I'd like it work, by
  moving some consts into head.js that are useful to all tests,
  and moving the zip file into the base tests directory instead
  of tests/browser
* Fix a lint error in browser_searchHomepage.js (the license
  comment)