### PR TITLE
Bug 1601210 - Don't show tip on DDG search results page.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -339,7 +339,12 @@ async function isDefaultEngineHomepage(urlStr) {
     urlStr = urlStr.slice(0, -1);
   }
 
-  return homepages.includes(urlStr);
+  return (
+    homepages.includes(urlStr) &&
+    // duckduckgo.com is a special case.  The home page and search results page
+    // have the same URL except the search results page has a "q" search param.
+    (urlStr != "duckduckgo.com" || !url.searchParams.has("q"))
+  );
 }
 
 /**

--- a/tests/tests/browser/browser_test.js
+++ b/tests/tests/browser/browser_test.js
@@ -207,6 +207,20 @@ add_task(async function ddgStartNotDefault() {
   });
 });
 
+// The redirect tip should not be shown for duckduckgo.com/?q=foo, the search
+// results page, which happens to have the same domain and path as the home
+// page.
+add_task(async function ddgSearchResultsPage() {
+  await setDefaultEngine("DuckDuckGo");
+  await withStudy({ branch: BRANCHES.TREATMENT }, async () => {
+    await withAddon(async () => {
+      await withDNSRedirect("duckduckgo.com", "/", async url => {
+        await checkTab(window, `${url}?q=test`, TIPS.NONE);
+      });
+    });
+  });
+});
+
 // The redirect tip should not be shown on a non-engine page.
 add_task(async function nonEnginePage() {
   await withStudy({ branch: BRANCHES.TREATMENT }, async () => {


### PR DESCRIPTION
I didn't update the browser_searchHomepage.js test since the
end-to-end test (browser_test.js, which I've updated here) checks
each of the engines' home pages. (And also I removed the
example.com mock home pages from the map a while ago, so that
test doesn't even pass anymore. I don't think it's super
important at this point. I guess we should remove it if we're not
going to keep it updated.)