### PR TITLE
Bug 1608613 - Call browser.experiments.urlbar.clearInput() to clear the input when the redirect tip is picked.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urlbar-tips",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Shows tips in the urlbar view in certain situations.",
   "private": true,
   "license": "MPLv2",

--- a/src/background.js
+++ b/src/background.js
@@ -331,6 +331,13 @@ async function onResultsRequested(query) {
  */
 async function onResultPicked(payload) {
   browser.urlbar.focus();
+
+  // UrlbarInput calls handleRevert when the tip is picked, which puts the
+  // current page's URL back into the input.  We want the input to be empty and
+  // showing the magnifying class icon (pageproxystate=invalid), so call
+  // clearInput now.
+  browser.experiments.urlbar.clearInput();
+
   // onEngagement will be called too.
 }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Urlbar Tips",
-  "version": "1.0",
+  "version": "1.0.1",
   "description": "Shows tips in the urlbar view in certain situations.",
   "applications": {
     "gecko": {

--- a/tests/tests/browser/browser.ini
+++ b/tests/tests/browser/browser.ini
@@ -5,6 +5,6 @@
 [DEFAULT]
 support-files =
   head.js
-  ../urlbar_tips-1.0.zip
+  ../urlbar_tips-1.0.1.zip
 
 [browser_test.js]

--- a/tests/tests/browser/head.js
+++ b/tests/tests/browser/head.js
@@ -17,7 +17,7 @@ XPCOMUtils.defineLazyModuleGetters(this, {
 });
 
 // The path of the add-on file relative to `getTestFilePath`.
-const ADDON_PATH = "urlbar_tips-1.0.zip";
+const ADDON_PATH = "urlbar_tips-1.0.1.zip";
 
 // Use SIGNEDSTATE_MISSING when testing an unsigned, in-development version of
 // the add-on and SIGNEDSTATE_PRIVILEGED when testing the production add-on.


### PR DESCRIPTION
This uses the clearInput function I'm adding in bug 1608601.
This clears the input for the onboarding tip too, not only the
redirect tip, but that's harmless because the input is already
cleared in that case, and if it weren't we'd want to clear it
then too.